### PR TITLE
Display an empty array when the folder of the application is missing …

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -69,9 +69,7 @@ class ApiController extends AbstractController
         $response = null;
 
         if ($option === 'all') {
-            $response = array_map(function (ApplicationInterface $application) {
-                return $application->getName();
-            }, $this->applicationService->getApplications());
+            $response = $this->getAllApplications();           
         } elseif ($this->applicationService->getApplication($option) !== null) {
             $response = $this->getForApplication($option);
         }
@@ -110,6 +108,13 @@ class ApiController extends AbstractController
         $this->downloadCounter->increaseCounter($application, $build);
 
         return new JsonResponse($build->getApiAnswer());
+    }
+
+    private function getAllApplications()
+    {
+        return array_map(function (ApplicationInterface $application) {
+            return $application->getName();
+        }, $this->applicationService->getApplications());
     }
 
     private function getForApplication(string $applicationName)

--- a/src/Service/BuildsService.php
+++ b/src/Service/BuildsService.php
@@ -6,6 +6,7 @@ use App\Application\ApplicationInterface;
 use App\Structs\Build;
 use App\Structs\BuildInterface;
 use App\Structs\LatestBuild;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Routing\RouterInterface;
@@ -132,6 +133,12 @@ class BuildsService
         $applicationPath = $this->getPathForApplication($application);
 
         $finder = new Finder();
+        $filesystem = new Filesystem();
+
+        if ($filesystem->exists($applicationPath) === false)  {
+            return [];
+        }
+
         $finder->files()->in($applicationPath);
 
         $builds = [];


### PR DESCRIPTION
### 1. Why is this change necessary?
A 500 internal server error is returned when an application exists but the folder where the builds are located not. _API endpoint: /list/{option?all}/{fileName}_ 

### 2. What does this change do, exactly?
When the folder doesn't exist it returns an empty array instead of a 500 response. Also included a small code refactor which moves some code into a separate function.

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
